### PR TITLE
Update UrlManager.php

### DIFF
--- a/UrlManager.php
+++ b/UrlManager.php
@@ -140,14 +140,13 @@ class UrlManager extends \yii\web\UrlManager
                 return $url;
             } else {
                 $baseUrl = $this->getBaseUrl();
+
                 $url = implode(self::SEPARATOR_PATH, [
                     $baseUrl,
                     $language,
-                    ltrim($url, $baseUrl),
+                    ltrim(str_replace('#' . $baseUrl, '', '#' . $url), '/'),
                 ]);
-                $pattern = sprintf('#%s{2,}#', self::SEPARATOR_PATH);
-                $url = preg_replace($pattern, self::SEPARATOR_PATH, $url);
-
+                
                 return $url;
             }
         } else {


### PR DESCRIPTION
ltrim will trim a charlist. It is not replace a prefix string to empty string.
I used a string with "#" prefix to replace first match and ltrim to remove "/" at the first position of route url.